### PR TITLE
Fixed subnet references in ecs service and alb.

### DIFF
--- a/iac/alb.tf
+++ b/iac/alb.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "main" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [ aws_security_group.alb.id ] 
-  subnets            = [ aws_subnet.public[0].id, aws_subnet.public[1].id ]
+  subnets            = aws_subnet.public[*].id
  
   enable_deletion_protection = false
 }

--- a/iac/ecr_service.tf
+++ b/iac/ecr_service.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_service" "main" {
  
  network_configuration {
    security_groups  = [ aws_security_group.alb.id, aws_security_group.ecs_tasks.id ] 
-   subnets          = [ aws_subnet.private[0].id, aws_subnet.private[1].id ]
+   subnets          = aws_subnet.private[*].id
    assign_public_ip = false
  }
 


### PR DESCRIPTION
Subnets were referenced individually instead which would cause deployment to break if only one subnet was created, or would miss references to any over 2.  Changed to splat to pull all available.